### PR TITLE
[chore] convert redis template to object composition

### DIFF
--- a/mkt/app/controllers/auth/Controller.php
+++ b/mkt/app/controllers/auth/Controller.php
@@ -26,10 +26,12 @@ class AuthController
 {   
     private UserRepository $userRepository;
     private DbTemplate $db;
+    private Session $session;
 
     public function __construct() {
         $this->db = new DbTemplate();
         $this->userRepository = new UserRepository($this->db->getPdo());    
+        $this->session = new Session();
     }
 
     public function signIn()
@@ -82,7 +84,7 @@ class AuthController
         $user = $this->userRepository->findByEmail($email);
 
         if (isset($user) && password_verify($pwd, $user["pwd"])) {
-            $sessionId  = Session::setSession($user["email"], $user["role"]);
+            $sessionId  = $this->session->setSession($user["email"], $user["role"]);
             Cookie::assignSessionCookie($sessionId);
             Controller::redirectToResult("Successfully logged in! Welcome!", "success");
         } else {

--- a/mkt/app/core/auth/Session.php
+++ b/mkt/app/core/auth/Session.php
@@ -7,11 +7,20 @@ include_once __DIR__ . "/../templates/RedisTemplate.php";
 
 use App\Core\Templates\RedisTemplate;
 use App\Core\Cookie;
+use Predis\Client;
 
 class Session extends RedisTemplate 
 {
-    public static function getSession() {
-        $redis = parent::getRedis();
+
+    private RedisTemplate $redis;
+
+    public function __construct()
+    {
+        $this->redis = new RedisTemplate();
+    }
+
+    public function getSession() {
+        $redis = $this->redis->getRedis();
 
         $session_id_cookie = $_COOKIE["session_id"] ?? "";
 
@@ -29,9 +38,9 @@ class Session extends RedisTemplate
         ];
     }
 
-    public static function setSession(string $email, string $role) 
+    public function setSession(string $email, string $role) 
     {       
-        $redis = parent::getredis();
+        $redis = $this->redis->getRedis();
 
         $EXPIRATION_DAYS = 60*60*24*30; // 30 days in seconds
         $sessionId = bin2hex(random_bytes(32));

--- a/mkt/app/core/controller/Controller.php
+++ b/mkt/app/core/controller/Controller.php
@@ -31,29 +31,29 @@ class Controller
     }
 
     public static function redirectIfAuth($returnSession = false) {
-        $session = new Session()->getSession();
+        $session = new Session();
         
-        if ($session) {
+        if ($session->getSession()) {
             header("Location: /auth/signout");
             exit();
         }
 
         if ($returnSession) {
-            return $session;
+            return $session->getSession();
         }
     }
 
     public static function redirectIfNotAuth($returnSession = false) 
     {
-        $session = new Session()->getSession();
+        $session = new Session();
         
-        if (!$session) {
+        if (!$session->getSession()) {
             header("Location: /auth/signin");
             exit();
         }
 
         if ($returnSession) {
-            return $session;
+            return $session->getSession();
         }
     }
 

--- a/mkt/app/core/controller/Controller.php
+++ b/mkt/app/core/controller/Controller.php
@@ -31,7 +31,7 @@ class Controller
     }
 
     public static function redirectIfAuth($returnSession = false) {
-        $session = Session::getSession(); 
+        $session = new Session()->getSession();
         
         if ($session) {
             header("Location: /auth/signout");
@@ -45,7 +45,8 @@ class Controller
 
     public static function redirectIfNotAuth($returnSession = false) 
     {
-        $session = Session::getSession(); 
+        $session = new Session()->getSession();
+        
         if (!$session) {
             header("Location: /auth/signin");
             exit();

--- a/mkt/app/core/mailer/VerificationCode.php
+++ b/mkt/app/core/mailer/VerificationCode.php
@@ -8,24 +8,24 @@ use App\Core\Templates\RedisTemplate;
 class VerificationCode extends RedisTemplate
 {
     public static function generateCode($email) {
-        $redis = new RedisTemplate()->getRedis();
+        $redis = new RedisTemplate();
 
         $code = rand(10000,99999);
 
         $expiration = 5 * 60; // 5 minutes in seconds
         
         // Use setex() instead of set() with TTL
-        $redis->setex($email, $expiration, $code);
+        $redis->getRedis()->setex($email, $expiration, $code);
 
         return $code;
     }
 
     public static function verifyCode($email, $code) {
-        $redis = new RedisTemplate()->getRedis();
-        $storedCode = $redis->get($email);
+        $redis = new RedisTemplate();
+        $storedCode = $redis->getRedis()->get($email);
         
         // Use del() instead of delete() - Redis command is DEL
-        $redis->del($email);
+        $redis->getRedis()->del($email);
         
         return $storedCode == $code; // == disregards type but not the actual value within it
     }

--- a/mkt/app/core/mailer/VerificationCode.php
+++ b/mkt/app/core/mailer/VerificationCode.php
@@ -8,7 +8,7 @@ use App\Core\Templates\RedisTemplate;
 class VerificationCode extends RedisTemplate
 {
     public static function generateCode($email) {
-        $redis = parent::getRedis();
+        $redis = new RedisTemplate()->getRedis();
 
         $code = rand(10000,99999);
 
@@ -21,7 +21,7 @@ class VerificationCode extends RedisTemplate
     }
 
     public static function verifyCode($email, $code) {
-        $redis = parent::getRedis();
+        $redis = new RedisTemplate()->getRedis();
         $storedCode = $redis->get($email);
         
         // Use del() instead of delete() - Redis command is DEL

--- a/mkt/app/core/templates/RedisTemplate.php
+++ b/mkt/app/core/templates/RedisTemplate.php
@@ -6,16 +6,24 @@ include_once __DIR__ . "/../../../utils/env.php";
 
 use Predis\Client;
 
-class RedisTemplate {
-    protected static function getRedis() {
+class RedisTemplate 
+{
+
+    private Client $redis;
+
+    public function __construct()
+    {
         global $env;
 
-        $redis = new Client([
+        $this->redis = new Client([
                     'scheme' => $env["REDIS_SCHEME"] ?? 'tcp',
                     'host'   => $env["REDIS_HOST"] ?? 'redis', 
                     'port'   => $env["REDIS_PORT"] ?? 6379,
                 ]);
+    }
 
-        return $redis;
+    public function getRedis()
+    {
+        return $this->redis;
     }
 }


### PR DESCRIPTION
To keep consistency and best practices alive within the codebase, migrate the RedisTemplate from a static class to a regular class (meaning its content will be attached to an object, not the class itself). Use object composition for the code to be used amongst other services within the codebase. 